### PR TITLE
Do not rebuild spdk-sys each time when cargo build is run

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -146,5 +146,4 @@ fn main() {
     println!("cargo:rustc-link-lib=crypto");
 
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=wrapper.h");
 }


### PR DESCRIPTION
wrapper.h was left over from old times when header files were hardcoded in wrapper.h file. Now they are dynamically generated from list of found header files in spdk include directory.