### PR TITLE
add wrapper to allow centralized logging from RUST

### DIFF
--- a/logwrapper.c
+++ b/logwrapper.c
@@ -1,0 +1,11 @@
+#include "wrapper.h"
+
+void
+maya_log(int level, const char *file, const int line, const char *func,
+    const char *format, va_list args)
+{
+    char buf[1024] = {0};
+    int n_written = vsnprintf(buf, sizeof(buf), format, args);
+    logfn(level, file, line, func, &buf[0], n_written);
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,30 @@
     unknown_lints
 )]
 
+use std::os::raw::c_char;
 include!(concat!(env!("OUT_DIR"), "/libspdk.rs"));
+
+pub type LogProto = Option<
+    extern "C" fn(
+        level: i32,
+        file: *const c_char,
+        line: u32,
+        func: *const c_char,
+        buf: *const c_char,
+        n: i32,
+    ),
+>;
+
+#[link(name = "logwrapper", kind = "static")]
+extern "C" {
+    pub fn maya_log(
+        level: i32,
+        file: *const c_char,
+        line: i32,
+        func: *const c_char,
+        format: *const c_char,
+        args: *mut __va_list_tag,
+    );
+
+    pub static mut logfn: LogProto;
+}

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,3 +1,13 @@
+#include <bdev/aio/bdev_aio.h>
+#include <bdev/crypto/vbdev_crypto.h>
+#include <bdev/iscsi/bdev_iscsi.h>
+#include <bdev/lvol/vbdev_lvol.h>
+#include <bdev/malloc/bdev_malloc.h>
+#include <bdev/nvme/bdev_nvme.h>
+#include <iscsi/init_grp.h>
+#include <iscsi/portal_grp.h>
+#include <iscsi/tgt_node.h>
+#include <nbd/nbd_internal.h>
 #include <spdk/assert.h>
 #include <spdk/barrier.h>
 #include <spdk/base64.h>
@@ -64,14 +74,9 @@
 #include <spdk/vhost.h>
 #include <spdk/vmd.h>
 #include <spdk_internal/lvolstore.h>
-#include <bdev/nvme/bdev_nvme.h>
-#include <bdev/malloc/bdev_malloc.h>
-#include <bdev/aio/bdev_aio.h>
-#include <bdev/lvol/vbdev_lvol.h>
-#include <bdev/iscsi/bdev_iscsi.h>
-#include <bdev/crypto/vbdev_crypto.h>
-#include <iscsi/init_grp.h>
-#include <iscsi/portal_grp.h>
-#include <iscsi/tgt_node.h>
-#include <nbd/nbd_internal.h>
 
+typedef void maya_logger(int level, const char *file, const int line,
+    const char *func, const char *buf, const int len);
+
+// pointer is set from within rust to point to our logging trampoline
+maya_logger *logfn = NULL;


### PR DESCRIPTION
We add a small C function that handles the va_list unpacking for us in C, and then call the function through the function pointer which is set by calling `spdk_open_log()`. This function pointer is a function that is implemented in rust. 